### PR TITLE
Add documentation on permissions required

### DIFF
--- a/label.js
+++ b/label.js
@@ -69,7 +69,7 @@ async function createLabels(options) {
     // create label, accept error code if it already exists
     console.log('Creating VeracodeFlaw labels');
 
-    var authToken = 'token ' + githubToken;
+    var authToken = 'Bearer ' + githubToken;
 
     for(const element of flawLabels.concat(otherLabels) ) {
         await request('POST /repos/{owner}/{repo}/labels', {


### PR DESCRIPTION
As a result of a customer running into issues with getting a 404 on label creation I dove into the permissions required and figured I'd update our documentation a bit on what's required.
I also think we should be telling customers to include `permissions` because by default this will not work without it.
And though I think we should be using auth-action rather than manually passing the token, it works but to increase compat a bit I think we should use Bearer instead of the non-standard `token`.

Let me know what you think!