### PR TITLE
Recommend major version tag instead of patch level version tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ If this is a new 'fine-grained, repository-scoped token' you will need to ensure
           name: filtered-results
 
       - name: import flaws as issues
-        uses: veracode/veracode-flaws-to-issues@v2.1.19
+        uses: veracode/veracode-flaws-to-issues@v2
         with:
           scan-results-json: 'filtered_results.json'
 ```
@@ -191,7 +191,7 @@ If this is a new 'fine-grained, repository-scoped token' you will need to ensure
           path: /tmp
 
       - name: import flaws as issues
-        uses: veracode/veracode-flaws-to-issues@v2.1.19
+        uses: veracode/veracode-flaws-to-issues@v2
         with:
           scan-results-json: '/tmp/policy_flaws.json'
 ```


### PR DESCRIPTION
Recommending users install a tag leads to them never updating to later (patch) versions. We should follow GitHub best practices and recommend a major version tag instead.

Please note that a `v2` tag will need to be created first.

Documentation from GitHub: https://github.com/actions/toolkit/blob/master/docs/action-versioning.md