### PR TITLE
Add "Get assistance" comment

### DIFF
--- a/issue.js
+++ b/issue.js
@@ -42,7 +42,7 @@ async function addVeracodeIssue(options, issue) {
             core.info('#### DEBUG END ####')
         }
         const mailToLink = buildMailToLink(
-            `https://github.com/${githubOwner}/${githubRepo}/issues/${issueNumber}`,
+            `https://github.com/${githubOwner}/${githubRepo}/issues/${issue_number}`,
             issue.flaw
         );
         await request('POST /repos/{owner}/{repo}/issues/{issue_number}/comments', {

--- a/issue.js
+++ b/issue.js
@@ -89,8 +89,7 @@ async function addVeracodeIssue(options, issue) {
 }
 
 function buildMailToLink(issueUrl, flaw) {
-    return encodeURIComponent(
-        'mailto:support@veracode.com?subject=' +
+    return 'mailto:support@veracode.com?subject=' +
         encodeURIComponent('[veracode/veracode-flaws-to-issues] Get Assistance') +
         '&body=' +
         encodeURIComponent(`Hi,
@@ -103,8 +102,7 @@ I'd like help with:
 [ ] Fixing this flaw
 [ ] Other, namely: [[ please describe here ]]
 
-Thank you.`)
-    );
+Thank you.`);
 }
 
 module.exports = { addVeracodeIssue };

--- a/issue.js
+++ b/issue.js
@@ -41,6 +41,22 @@ async function addVeracodeIssue(options, issue) {
             console.log("isPr?: "+options.isPR)
             core.info('#### DEBUG END ####')
         }
+        const mailToLink = buildMailToLink(
+            `https://github.com/${githubOwner}/${githubRepo}/issues/${issueNumber}`,
+            issue.flaw
+        );
+        await request('POST /repos/{owner}/{repo}/issues/{issue_number}/comments', {
+            headers: {
+                authorization: authToken
+            },
+            owner: githubOwner,
+            repo: githubRepo,
+            issue_number: issue_number,
+            data: {
+                "body": `Don't know how to fix this? Don't know why this was reported?<br>
+                <a href="${mailToLink}">Get Assistance from Veracode</a>`
+            }
+        });
         if ( issue.pr_link != "" && options.isPR >=1 ){
             console.log('Running on a PR, adding PR to the issue.')
             //console.log('pr_link: '+issue.pr_link+'\nissue_number: '+issue_number)
@@ -70,6 +86,25 @@ async function addVeracodeIssue(options, issue) {
             throw new Error (`Error ${error.status} creating Issue for \"${issue.title}\": ${error.message}`);
         }           
     });
+}
+
+function buildMailToLink(issueUrl, flaw) {
+    return encodeURIComponent(
+        'mailto:support@veracode.com?subject=' +
+        encodeURIComponent('[veracode/veracode-flaws-to-issues] Get Assistance') +
+        '&body=' +
+        encodeURIComponent(`Hi,
+
+Could you please help me with: ${issueUrl}.
+A CWE-${flaw.cwe.id}: ${flaw.cwe.name} flaw reported on line ${flaw.lineNumber} of ${flaw.file} .
+
+I'd like help with:
+[ ] Understanding why this flaw was reported
+[ ] Fixing this flaw
+[ ] Other, namely: [[ please describe here ]]
+
+Thank you.`)
+    );
 }
 
 module.exports = { addVeracodeIssue };

--- a/pipeline.js
+++ b/pipeline.js
@@ -284,6 +284,15 @@ async function processPipelineFlaws(options, flawData) {
         bodyText += '\n\n' + decodeURI(flaw.display_text);
 
         let issue = {
+            'flaw': {
+                'id': flaw.issue_id,
+                'cwe': {
+                    'id': flaw.finding_details.cwe.id,
+                    'name': flaw.finding_details.cwe.name
+                },
+                'lineNumber': flaw.finding_details.file_line_number,
+                'file': flaw.finding_details.file_name
+            },
             'title': title,
             'label': lableBase,
             'severity': severity,

--- a/pipeline.js
+++ b/pipeline.js
@@ -285,13 +285,12 @@ async function processPipelineFlaws(options, flawData) {
 
         let issue = {
             'flaw': {
-                'id': flaw.issue_id,
                 'cwe': {
-                    'id': flaw.finding_details.cwe.id,
-                    'name': flaw.finding_details.cwe.name
+                    'id': flaw.cwe_id,
+                    'name': flaw.issue_type
                 },
-                'lineNumber': flaw.finding_details.file_line_number,
-                'file': flaw.finding_details.file_name
+                'lineNumber': flaw.files.source_file.line,
+                'file': flaw.files.source_file.file
             },
             'title': title,
             'label': lableBase,

--- a/policy.js
+++ b/policy.js
@@ -258,6 +258,14 @@ async function processPolicyFlaws(options, flawData) {
         //console.log('bodyText: '+bodyText)
 
         let issue = {
+            'flaw': {
+                'cwe': {
+                    'id': flaw.finding_details.cwe.id,
+                    'name': flaw.finding_details.cwe.name
+                },
+                'lineNumber': flaw.finding_details.file_line_number,
+                'file': flaw.finding_details.file_name
+            },
             'title': title,
             'label': lableBase,
             'severity': severity,


### PR DESCRIPTION
Adds:

> Don't know how to fix this? Don't know why this was reported?
> 
> [Get Assistance from Veracode](mailto:support@veracode.com?subject=%5Bveracode%2Fveracode-flaws-to-issues%5D%20Get%20Assistance&body=Hi%2C%0A%0ACould%20you%20please%20help%20me%20with%3A%20https%3A%2F%2Fgithub.com%2Frelaxnow%2Fveracode-container-security-display%2Fissues%2F25.%0AA%20CWE-117%3A%20Improper%20Output%20Neutralization%20for%20Logs%20flaw%20reported%20on%20line%2035%20of%20js%2Fmitigations.js%20.%0A%0AI%27d%20like%20help%20with%3A%0A%5B%20%5D%20Understanding%20why%20this%20flaw%20was%20reported%0A%5B%20%5D%20Fixing%20this%20flaw%0A%5B%20%5D%20Other%2C%20namely%3A%20%5B%5B%20please%20describe%20here%20%5D%5D%0A%0AThank%20you.)

To advertise Veracode Application Security Consulting services.

Example flaw: https://github.com/relaxnow/veracode-container-security-display/issues/25